### PR TITLE
Make sure extension is linked with $ICU_LIBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ DATA = $(wildcard sql/*.sql)
 
 MODULE_big = icu_ext
 OBJS      = icu_ext.o icu_break.o icu_num.o icu_spoof.o icu_transform.o
+SHLIB_LINK = $(ICU_LIBS)
 
 all:
 


### PR DESCRIPTION
When I tried building this extension with Postgres.app, it failed to link:

```
Undefined symbols for architecture x86_64:
  "_u_charName_62", referenced from:
      _icu_char_name in icu_ext.o
(...)
```

The problem seems to be that the `-licui18n -licuuc` linker flags were missing, so the extension was not linked with ICU.

The fix was to make sure the extension is linked with $ICU_LIBS