### PR TITLE
Fix compatibility with icu 70

### DIFF
--- a/icu_normalize.c
+++ b/icu_normalize.c
@@ -155,5 +155,5 @@ icu_is_normalized(PG_FUNCTION_ARGS)
 	if (U_FAILURE(status))
 		elog(ERROR, "unorm2_isNormalized failure: %s", u_errorName(status));
 
-	PG_RETURN_BOOL(is_norm == TRUE);
+	PG_RETURN_BOOL(is_norm == 1);
 }


### PR DESCRIPTION
ICU 70 no longer defines TRUE as 1, causing a failure to build in Ubuntu. We make this trivial change to allow this to build against icu 70.